### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/btsync/client.py
+++ b/btsync/client.py
@@ -41,7 +41,7 @@ class Client(object):
         self._password = kwargs.pop('password', 'password')
 
         assert len(kwargs.keys()) == 0, \
-            "Unrecognized params: %r" % kwargs.keys()
+            "Unrecognized params: {0!r}".format(kwargs.keys())
         self._session = self._authenticate()
 
     def _make_request(self, **kwargs):
@@ -65,7 +65,7 @@ class Client(object):
 
         method = getattr(
             session if session is not None else self._session, method)
-        assert method is not None, 'Invalid method: %s' % method
+        assert method is not None, 'Invalid method: {0!s}'.format(method)
 
         response = method(url)
         response.raise_for_status()

--- a/btsync/models.py
+++ b/btsync/models.py
@@ -7,7 +7,7 @@ class Model(dict):
                 value = params.pop(field)
                 self[field] = factory(value)
 
-        assert len(params) == 0, "Unrecognized params: %r" % params.keys()
+        assert len(params) == 0, "Unrecognized params: {0!r}".format(params.keys())
 
 
 class Settings(Model):

--- a/fabfile.py
+++ b/fabfile.py
@@ -3,7 +3,7 @@ from fabric.api import local
 
 def _run_coverage_for(kind):
     assert kind in ('unit', 'integration', '')
-    test_folder = 'test/%s' % kind
+    test_folder = 'test/{0!s}'.format(kind)
     local('coverage run --source=btsync,%(test_folder)s '
           '$(which nosetests) %(test_folder)s' % dict(
               test_folder=test_folder))

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -34,7 +34,7 @@ class TestIntegration(object):
 
         with open(config_file_name, 'w') as f:
             CONFIG['storage_path'] = storage_path
-            CONFIG['webui']['listen'] = '0.0.0.0:%s' % PORT
+            CONFIG['webui']['listen'] = '0.0.0.0:{0!s}'.format(PORT)
             json.dump(CONFIG, f)
 
         self.btsync_process = subprocess.Popen([


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:kevinjqiu:btsync.py?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:kevinjqiu:btsync.py?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
